### PR TITLE
添加单元测试和 TravisCI

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,22 +5,11 @@
         {
           "targets": {
             "browsers": ["> 1%", "last 2 versions", "not ie <= 8"]
-          },
-          "modules": false,
-          "debug": true,
-          "uglify": true,
-          "useBuiltIns": true
+          }
         },
         "es2015"
       ]
     ],
     "plugins": [
-      ["@babel/plugin-transform-typescript"],
-      ["@babel/plugin-transform-arrow-functions", { "spec": true }],
-      ["@babel/plugin-transform-block-scoping"],
-      ["@babel/plugin-transform-classes"],
-      ["@babel/plugin-transform-runtime"],
-      ["@babel/plugin-transform-modules-umd"],
-      ["@babel/plugin-transform-class-properties"]
     ]
   }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: node_js
+branches:
+  only:
+    - master
+    - /v[0-9]+(\.[0-9]+).*/
+node_js:
+  - 10
+install:
+  - npm ci
+script:
+  - npm test
+  - echo "$TRAVIS_EVENT_TYPE"
+  - echo "$TRAVIS_TAG"
+  - echo "$TRAVIS_BRANCH"
+  - echo "$TRAVIS_BUILD_STAGE_NAME"
+before_deploy:
+  - npm run product
+deploy:
+  provider: npm
+  email: "$NPM_EMAIL"
+  api_token: "$NPM_TOKEN"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    verbose: true,
+    // moduleFileExtensions: [
+    //     'js',
+    //     'json',
+    // ],
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "webpack --config config/webpack.dev.js --watch",
     "start": "node config/dev-server.js & npm run watch",
-    "prod": "node config/build.js && webpack --config config/webpack.prod.js --verbose"
+    "prod": "node config/build.js && webpack --config config/webpack.prod.js --verbose",
+    "test": "jest --config jest.config.js"
   },
   "repository": {
     "type": "git",
@@ -18,15 +19,17 @@
   "author": "VIPKID EDU XYZ",
   "license": "MIT",
   "devDependencies": {
+    "@babel/preset-env": "^7.9.5",
     "@types/node": "^13.11.1",
     "@types/webpack": "^4.41.11",
-    "eslint": "6.6.0",
     "@typescript-eslint/eslint-plugin": "2.6.1",
     "@typescript-eslint/parser": "2.6.1",
+    "copy-webpack-plugin": "5.0.5",
     "cross-env": "^6.0.3",
+    "eslint": "6.6.0",
     "filemanager-webpack-plugin": "^2.0.5",
     "html-webpack-plugin": "3.2.0",
-    "copy-webpack-plugin": "5.0.5",
+    "jest": "^25.4.0",
     "ts-loader": "6.1.0",
     "ts-node": "^8.8.2",
     "typescript": "^3.7.2",

--- a/unit-test/launcher.test.js
+++ b/unit-test/launcher.test.js
@@ -1,0 +1,3 @@
+test('test', () => {
+    expect(3).toBe(3)
+})


### PR DESCRIPTION
**变动**
- 针对单元测试框架 `jest`支持, 对 `.babelrc` 配置进行了变动，具体请看 diff
- 针对单元测试框架 `jest` 支持， `package.json` 引入并更新了相关依赖

**新增**
- 根目录下新增了 `.travis.yml` CI 配置文件
- 根目录下新增了 `unit-test/` 单元测试文件夹，存放有关单元测试的 case
